### PR TITLE
sync yim & add changes

### DIFF
--- a/src/backend/looped/system/self_globals.cpp
+++ b/src/backend/looped/system/self_globals.cpp
@@ -23,6 +23,13 @@ namespace big
 		else
 			self::veh = 0;
 
-		self::last_veh = PLAYER::GET_PLAYERS_LAST_VEHICLE();
+		if (g_local_player && g_local_player->m_vehicle)
+		{
+			Vehicle veh = g_pointers->m_gta.m_ptr_to_handle(g_local_player->m_vehicle);
+			if (ENTITY::DOES_ENTITY_EXIST(veh) && !ENTITY::IS_ENTITY_DEAD(veh, 0))
+				self::last_veh = veh;
+		}
+		else
+			self::last_veh = 0;
 	}
 }

--- a/src/core/data/network.hpp
+++ b/src/core/data/network.hpp
@@ -4,7 +4,6 @@ namespace big
 {
 	inline struct g_network
 	{
-		bool network_player_mgr_init;
 		bool auto_kick_host_when_attacked;
 	} g_network{};
 }

--- a/src/hooks/player_management/network_player_mgr.cpp
+++ b/src/hooks/player_management/network_player_mgr.cpp
@@ -11,7 +11,6 @@ namespace big
 		bool result = g_hooking->get_original<hooks::network_player_mgr_init>()(_this, a2, a3, a4);
 
 		g_player_service->player_join(_this->m_local_net_player);
-		g_network.network_player_mgr_init = true;
 
 		return result;
 	}
@@ -20,7 +19,6 @@ namespace big
 	{
 		g_player_service->do_cleanup();
 		self::spawned_vehicles.clear();
-		g_network.network_player_mgr_init      = false;
 		g_network.auto_kick_host_when_attacked = false;
 
 		g_hooking->get_original<hooks::network_player_mgr_shutdown>()(_this);

--- a/src/hooks/protections/send_non_physical_player_data.cpp
+++ b/src/hooks/protections/send_non_physical_player_data.cpp
@@ -22,8 +22,10 @@ namespace big
 		{
 			data->m_bubble_id = 10;
 
-			if (auto plyr = g_player_service->get_by_id(player->m_player_id); plyr && !plyr->is_blocked)
+			if (auto plyr = g_player_service->get_by_id(player->m_player_id); plyr && !plyr->join_prevented)
 			{
+				plyr->join_prevented = true;
+				
 				auto str = get_blocked_player_joined_log_string(plyr);
 
 				if (plyr->is_spammer)

--- a/src/services/players/player.hpp
+++ b/src/services/players/player.hpp
@@ -80,10 +80,11 @@ namespace big
 
 		bool is_modder = false;
 		std::unordered_set<int> infractions;
-		bool is_blocked         = false;
-		bool is_spammer         = false;
+		bool is_blocked     = false;
+		bool join_prevented = false;
+		bool is_spammer     = false;
 		std::string spam_message;
-		bool is_toxic        = false;
+		bool is_toxic = false;
 
 		std::optional<uint32_t> player_time_value;
 		std::optional<std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>> player_time_value_received_time;

--- a/src/services/vehicle/model_attachment.hpp
+++ b/src/services/vehicle/model_attachment.hpp
@@ -11,7 +11,6 @@ namespace big
 		Vector3 rotation;
 		bool has_collision;
 		bool is_visible;
-		bool is_invincible;
 	};
 
 	static void to_json(nlohmann::json& j, const model_attachment& attachment)
@@ -25,8 +24,6 @@ namespace big
 		    {"rotation_z", attachment.rotation.z},
 		    {"has_collision", attachment.has_collision},
 		    {"is_visible", attachment.is_visible},
-		    {"is_invincible", attachment.is_invincible}
-
 		};
 	};
 
@@ -44,6 +41,5 @@ namespace big
 
 		set_from_key_or_default(j, "has_collision", attachment.has_collision);
 		set_from_key_or_default(j, "is_visible", attachment.is_visible, true);
-		set_from_key_or_default(j, "is_invincible", attachment.is_invincible);
 	}
 };

--- a/src/services/vehicle/persist_car_service.cpp
+++ b/src/services/vehicle/persist_car_service.cpp
@@ -112,6 +112,13 @@ namespace big
 
 		VEHICLE::SET_VEHICLE_DIRT_LEVEL(vehicle, 0.0f);
 		VEHICLE::SET_VEHICLE_MOD_KIT(vehicle, 0);
+
+		if (!vehicle_json[tire_can_burst].is_null())
+			VEHICLE::SET_VEHICLE_TYRES_CAN_BURST(vehicle, vehicle_json[tire_can_burst]);
+
+		if (!vehicle_json[drift_tires].is_null())
+			VEHICLE::SET_DRIFT_TYRES(vehicle, vehicle_json[drift_tires]);
+
 		VEHICLE::SET_VEHICLE_COLOURS(vehicle, vehicle_json[primary_color_key], vehicle_json[secondary_color_key]);
 
 		if (!vehicle_json[custom_primary_color_key].is_null())
@@ -229,11 +236,11 @@ namespace big
 		bool has_collision                  = ENTITY::GET_ENTITY_COLLISION_DISABLED(vehicle);
 		bool is_visible                     = ENTITY::IS_ENTITY_VISIBLE(vehicle);
 		CVehicle* cvehicle                  = (CVehicle*)g_pointers->m_gta.m_handle_to_ptr(vehicle);
-		bool is_invincible                  = misc::has_bit_set(&(int&)cvehicle->m_damage_bits, 8);
 		vehicle_json[has_collision_key]     = !has_collision;
 		vehicle_json[is_visible_key]        = is_visible;
-		vehicle_json[is_invincible_key]     = is_invincible;
 		vehicle_json[wheel_color_key]       = wheel_color;
+		vehicle_json[tire_can_burst]        = VEHICLE::GET_VEHICLE_TYRES_CAN_BURST(vehicle);
+		vehicle_json[drift_tires]           = VEHICLE::GET_DRIFT_TYRES_SET(vehicle);
 
 		std::map<int, bool> vehicle_extras;
 		for (int extra_iterator = 0; extra_iterator <= 14; extra_iterator++)

--- a/src/services/vehicle/persist_car_service.hpp
+++ b/src/services/vehicle/persist_car_service.hpp
@@ -20,9 +20,8 @@ namespace big
 		static constexpr auto model_attachments_key = "model_attachments";
 
 		static constexpr auto vehicle_attachments_key = "vehicle_attachments";
-		static constexpr auto is_invincible_key       = "is_invincible";
-		static constexpr auto is_visible_key          = "is_visible";
-		static constexpr auto has_collision_key       = "has_collision";
+		static constexpr auto is_visible_key    = "is_visible";
+		static constexpr auto has_collision_key = "has_collision";
 
 		static constexpr auto vehicle_model_hash_key = "vehicle_model_hash";
 
@@ -38,6 +37,8 @@ namespace big
 		static constexpr auto wheel_type_key       = "wheel_type";
 		static constexpr auto wheel_color_key      = "wheel_color";
 		static constexpr auto tire_smoke_color_key = "tire_smoke_color";
+		static constexpr auto tire_can_burst       = "tire_can_burst";
+		static constexpr auto drift_tires          = "drift_tires";
 
 		static constexpr auto convertable_state_key = "convertable_state";
 

--- a/src/views/network/view_bad_players.cpp
+++ b/src/views/network/view_bad_players.cpp
@@ -105,24 +105,44 @@ namespace big
 		if (selected_id)
 		{
 			ImGui::Spacing();
-			ImGui::Text("Selected Player - ");
+			
+			components::sub_title("Selected Player");
+
 			ImGui::Spacing();
-			ImGui::Text(bad_players_nm::bad_players_list[selected_id].name.c_str());
-			ImGui::Text(std::to_string(selected_id).c_str());
 
-			auto block_join = bad_players_nm::bad_players_list[selected_id].block_join;
-			auto is_spammer = bad_players_nm::bad_players_list[selected_id].is_spammer;
+			ImGui::BeginGroup();
+			{
+				ImGui::Text(bad_players_nm::bad_players_list[selected_id].name.c_str());
+				ImGui::SameLine();
+				if (ImGui::SmallButton("Copy##copyname"))
+					ImGui::SetClipboardText(bad_players_nm::bad_players_list[selected_id].name.c_str());
 
-			if (ImGui::Checkbox("Block Join", &block_join))
-				g_thread_pool->push([block_join] {
-					bad_players_nm::toggle_block(selected_id, block_join);
-					searched_blocked_players.clear();
-				});
+				ImGui::Spacing();
 
-			if (ImGui::Checkbox("Is Spammer", &is_spammer))
-				g_thread_pool->push([is_spammer] {
-					bad_players_nm::set_spammer(selected_id, is_spammer);
-				});
+				ImGui::Text(std::to_string(selected_id).c_str());
+				ImGui::SameLine();
+				if (ImGui::SmallButton("Copy##copyrid"))
+					ImGui::SetClipboardText(std::to_string(selected_id).c_str());
+			}
+			ImGui::EndGroup();
+			ImGui::SameLine(0, 2.0f * ImGui::GetTextLineHeight());
+			ImGui::BeginGroup();
+			{
+				auto block_join = bad_players_nm::bad_players_list[selected_id].block_join;
+				auto is_spammer = bad_players_nm::bad_players_list[selected_id].is_spammer;
+
+				if (ImGui::Checkbox("Block Join", &block_join))
+					g_thread_pool->push([block_join] {
+						bad_players_nm::toggle_block(selected_id, block_join);
+						searched_blocked_players.clear();
+					});
+
+				if (ImGui::Checkbox("Is Spammer", &is_spammer))
+					g_thread_pool->push([is_spammer] {
+						bad_players_nm::set_spammer(selected_id, is_spammer);
+					});
+			}
+			ImGui::EndGroup();
 		}
 	}
 }

--- a/src/views/network/view_network.cpp
+++ b/src/views/network/view_network.cpp
@@ -105,7 +105,7 @@ namespace big
 			ImGui::Checkbox("Force Thunder globally", &g_session.force_thunder);
 
 			ImGui::Checkbox("Spoof god mod", &g_session.spoof_hide_god);
-			
+
 			ImGui::Checkbox("Spoof spectate", &g_session.spoof_hide_spectate);
 		}
 		ImGui::EndGroup();
@@ -139,7 +139,7 @@ namespace big
 				ImGui::EndListBox();
 			}
 
-			if (g_network.network_player_mgr_init)
+			if (*g_pointers->m_gta.m_is_session_started)
 			{
 				ImGui::Spacing();
 				components::button("Leave GTA Online", [] {

--- a/src/views/players/view_player.cpp
+++ b/src/views/players/view_player.cpp
@@ -276,6 +276,8 @@ namespace big
 			// ImGui::BeginDisabled(globals::get_interior_from_player(current_player->id()) != 0);
 			components::player_command_button<"kill">(current_player, {});
 
+			components::player_command_button<"explode">(current_player, {});
+
 			components::player_command_button<"vehkick">(current_player, {});
 
 			components::button("Stop Vehicle", [current_player] {

--- a/src/views/settings/view_debug_misc.cpp
+++ b/src/views/settings/view_debug_misc.cpp
@@ -20,6 +20,10 @@ namespace big
 				INTERIOR::REFRESH_INTERIOR(interior);
 			});
 			ImGui::Spacing();
+			components::button("Leave GTA Online", [] {
+				session::join_type(eSessionType::LEAVE_ONLINE);
+			});
+			ImGui::Spacing();
 			components::button("Network Shutdown and Load Most Recent Save", [] {
 				NETWORK::SHUTDOWN_AND_LOAD_MOST_RECENT_SAVE();
 			});

--- a/src/views/vehicle/spawn/view_persist_car.cpp
+++ b/src/views/vehicle/spawn/view_persist_car.cpp
@@ -136,7 +136,7 @@ namespace big
 				std::transform(pair_lower.begin(), pair_lower.end(), pair_lower.begin(), tolower);
 				if (pair_lower.contains(lower_search))
 				{
-					if (ImGui::Selectable(pair.c_str(), selected_vehicle_file == pair))
+					if (ImGui::Selectable(pair.c_str(), selected_vehicle_file == pair, ImGuiSelectableFlags_AllowItemOverlap))
 					{
 						selected_vehicle_file = pair;
 						g_fiber_pool->queue_job([spawn_at_waypoint] {

--- a/src/views/vehicle/view_vehicle.cpp
+++ b/src/views/vehicle/view_vehicle.cpp
@@ -99,8 +99,6 @@ namespace big
 			components::command_checkbox<"vehjump">();
 
 			components::command_checkbox<"blockhoming">();
-
-			components::command_checkbox<"keepengine">();
 		}
 		ImGui::EndGroup();
 		ImGui::SameLine();
@@ -189,7 +187,7 @@ namespace big
 		static bool veh_all_door_open     = false;
 		static const char* selected_radio = "OFF";
 		static std::map<int, bool> seats;
-		static bool is_lowrider, force_lowrider;
+		static bool force_lowrider;
 		static float maxWheelRaiseFactor = 2;
 		static bool indicator_left, indicator_right;
 
@@ -209,9 +207,6 @@ namespace big
 					seats = tmp_seats;
 
 					door_locked_state = (eVehicleLockState)VEHICLE::GET_VEHICLE_DOOR_LOCK_STATUS(self::last_veh);
-
-					if (VEHICLE::IS_TOGGLE_MOD_ON(self::last_veh, 18))
-						is_lowrider = true;
 				});
 			}
 
@@ -391,7 +386,7 @@ namespace big
 
 					ImGui::Spacing();
 
-					if (force_lowrider || is_lowrider)
+					if (force_lowrider)
 					{
 						ImGui::SetNextItemWidth(200);
 						ImGui::SliderFloat("maxWheelRaiseFactor", &maxWheelRaiseFactor, 1, 4);
@@ -465,7 +460,7 @@ namespace big
 			components::small_text("Please sit in a vehicle");
 			if (is_veh_checked)
 			{
-				is_lowrider = is_veh_checked = false;
+				force_lowrider = is_veh_checked = false;
 				seats.clear();
 			}
 		}


### PR DESCRIPTION
- replace PLAYER::GET_PLAYERS_LAST_VEHICLE with
  g_local_player->m_vehicle
- remove network_player_mgr_init boolean
- add join_prevented property to player
- refractor ui of bad_players
- when Send Message via view_chat, close the menu before
- restore player explode button
- add Leave GTA Online button to debug
- restore ImGuiSelectableFlags_AllowItemOverlap flag ->
  fixes persist_car_service delete button not working
  
  
 possible crash reasons with previous builds -
 
1. adding `self::last_veh = PLAYER::GET_PLAYERS_LAST_VEHICLE();` in `void looped::system_self_globals()`
2. `if (VEHICLE::IS_TOGGLE_MOD_ON(self::last_veh, 18))`
